### PR TITLE
Add optionalWhen variant

### DIFF
--- a/src/schema/boolean.ts
+++ b/src/schema/boolean.ts
@@ -51,3 +51,20 @@ boolean.optional = function optionalBoolean(options?: SchemaFnOptions) {
     return castToBoolean(key, value, options?.message)
   }
 }
+
+/**
+ * Same as the optional rule, but allows a condition to decide when to
+ * validate the value
+ */
+boolean.optionalWhen = function optionalWhenBoolean(
+  condition: boolean | ((key: string, value?: string) => boolean),
+  options?: SchemaFnOptions
+) {
+  return function validate(key: string, value?: string): boolean | undefined {
+    if (typeof condition === 'function' ? condition(key, value) : condition) {
+      return boolean.optional(options)(key, value)
+    }
+
+    return boolean(options)(key, value)
+  }
+}

--- a/src/schema/number.ts
+++ b/src/schema/number.ts
@@ -48,3 +48,20 @@ number.optional = function optionalNumber(options?: SchemaFnOptions) {
     return castToNumber(key, value, options?.message)
   }
 }
+
+/**
+ * Same as the optional rule, but allows a condition to decide when to
+ * validate the value
+ */
+number.optionalWhen = function optionalWhenNumber(
+  condition: boolean | ((key: string, value?: string) => boolean),
+  options?: SchemaFnOptions
+) {
+  return function validate(key: string, value?: string): number | undefined {
+    if (typeof condition === 'function' ? condition(key, value) : condition) {
+      return number.optional(options)(key, value)
+    }
+
+    return number(options)(key, value)
+  }
+}

--- a/src/schema/string.ts
+++ b/src/schema/string.ts
@@ -82,3 +82,20 @@ string.optional = function optionalString(options?: StringFnOptions) {
     return value
   }
 }
+
+/**
+ * Same as the optional rule, but allows a condition to decide when to
+ * validate the value
+ */
+string.optionalWhen = function optionalWhenString(
+  condition: boolean | ((key: string, value?: string) => boolean),
+  options?: StringFnOptions
+) {
+  return function validate(key: string, value?: string): string | undefined {
+    if (typeof condition === 'function' ? condition(key, value) : condition) {
+      return string.optional(options)(key, value)
+    }
+
+    return string(options)(key, value)
+  }
+}

--- a/tests/schema.spec.ts
+++ b/tests/schema.spec.ts
@@ -154,6 +154,32 @@ test.group('schema | string.optional', () => {
       'mailgun:1234/v1'
     )
   })
+
+  test('allow conditional optional', ({ assert, expectTypeOf }) => {
+    const value = schema.string.optionalWhen(true)('PORT')
+    expectTypeOf(value).toEqualTypeOf<string | undefined>()
+    assert.deepEqual(value, undefined)
+
+    const value2 = schema.string.optionalWhen(false)('PORT', '22')
+    expectTypeOf(value2).toEqualTypeOf<string | undefined>()
+    assert.deepEqual(value2, '22')
+
+    const fn = () => schema.string.optionalWhen(false)('PORT')
+    assert.throws(fn, 'Missing environment variable "PORT"')
+  })
+
+  test('allow conditional optional with function', ({ assert, expectTypeOf }) => {
+    const value = schema.string.optionalWhen(() => true)('PORT')
+    expectTypeOf(value).toEqualTypeOf<string | undefined>()
+    assert.deepEqual(value, undefined)
+
+    const value2 = schema.string.optionalWhen(() => false)('PORT', '22')
+    expectTypeOf(value2).toEqualTypeOf<string | undefined>()
+    assert.deepEqual(value2, '22')
+
+    const fn = () => schema.string.optionalWhen(() => false)('PORT')
+    assert.throws(fn, 'Missing environment variable "PORT"')
+  })
 })
 
 test.group('schema | boolean', () => {

--- a/tests/schema.spec.ts
+++ b/tests/schema.spec.ts
@@ -290,6 +290,32 @@ test.group('schema | boolean.optional', () => {
     expectTypeOf(value).toEqualTypeOf<boolean | undefined>()
     assert.deepEqual(value, false)
   })
+
+  test('allow conditional optional', ({ assert, expectTypeOf }) => {
+    const value = schema.boolean.optionalWhen(true)('PORT')
+    expectTypeOf(value).toEqualTypeOf<boolean | undefined>()
+    assert.deepEqual(value, undefined)
+
+    const value2 = schema.boolean.optionalWhen(false)('PORT', 'true')
+    expectTypeOf(value2).toEqualTypeOf<boolean | undefined>()
+    assert.deepEqual(value2, true)
+
+    const fn = () => schema.boolean.optionalWhen(false)('PORT')
+    assert.throws(fn, 'Missing environment variable "PORT"')
+  })
+
+  test('allow conditional optional with function', ({ assert, expectTypeOf }) => {
+    const value = schema.boolean.optionalWhen(() => true)('PORT')
+    expectTypeOf(value).toEqualTypeOf<boolean | undefined>()
+    assert.deepEqual(value, undefined)
+
+    const value2 = schema.boolean.optionalWhen(() => false)('PORT', 'true')
+    expectTypeOf(value2).toEqualTypeOf<boolean | undefined>()
+    assert.deepEqual(value2, true)
+
+    const fn = () => schema.boolean.optionalWhen(() => false)('PORT')
+    assert.throws(fn, 'Missing environment variable "PORT"')
+  })
 })
 
 test.group('schema | enum', () => {

--- a/tests/schema.spec.ts
+++ b/tests/schema.spec.ts
@@ -80,6 +80,32 @@ test.group('schema | number.optional', () => {
     expectTypeOf(value).toEqualTypeOf<number | undefined>()
     assert.deepEqual(value, -22.198)
   })
+
+  test('allow conditional optional', ({ assert, expectTypeOf }) => {
+    const value = schema.number.optionalWhen(true)('PORT')
+    expectTypeOf(value).toEqualTypeOf<number | undefined>()
+    assert.isUndefined(value)
+
+    const value2 = schema.number.optionalWhen(false)('PORT', '22')
+    expectTypeOf(value2).toEqualTypeOf<number | undefined>()
+    assert.deepEqual(value2, 22)
+
+    const fn = () => schema.number.optionalWhen(false)('PORT')
+    assert.throws(fn, 'Missing environment variable "PORT"')
+  })
+
+  test('allow conditional optional with function', ({ assert, expectTypeOf }) => {
+    const value = schema.number.optionalWhen(() => true)('PORT')
+    expectTypeOf(value).toEqualTypeOf<number | undefined>()
+    assert.isUndefined(value)
+
+    const value2 = schema.number.optionalWhen(() => false)('PORT', '22')
+    expectTypeOf(value2).toEqualTypeOf<number | undefined>()
+    assert.deepEqual(value2, 22)
+
+    const fn = () => schema.number.optionalWhen(() => false)('PORT')
+    assert.throws(fn, 'Missing environment variable "PORT"')
+  })
 })
 
 test.group('schema | string', () => {


### PR DESCRIPTION
Hey there! 👋🏻 

This PR introduces a new variant to `schema.x.optional` called `schema.x.optionalWhen()`. 

This new method makes it easier to handle environment-dependent validations. For example, you might want certain environment variables (like `SMTP_HOST` and `SMTP_PORT`) to be required in development, but completely optional in production.

Currently, you'd have to write something like this:

```ts
{
  ...(process.env.NODE_ENV === 'production'
    ? {
        BREVO_API_KEY: Env.schema.string(),
        SMTP_HOST: Env.schema.string.optional(),
        SMTP_PORT: Env.schema.string.optional(),
      }
    : {
        BREVO_API_KEY: Env.schema.string.optional(),
        SMTP_HOST: Env.schema.string(),
        SMTP_PORT: Env.schema.string(),
      }),
}
```

With the new `optionalWhen()` method, you can simplify this logic by directly specifying the condition:

```ts
{
  BREVO_API_KEY: Env.schema.string.optionalWhen(process.env.NODE_ENV !== 'production'),
  SMTP_HOST: Env.schema.string.optionalWhen(process.env.NODE_ENV === 'production'),
  SMTP_PORT: Env.schema.string.optionalWhen(process.env.NODE_ENV === 'production'),
}
```

This makes your validation more straightforward and readable, especially when working with different environments.